### PR TITLE
Updated to work with Subversion Edge

### DIFF
--- a/src/main/java/hudson/plugins/viewVC/ViewVCRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/viewVC/ViewVCRepositoryBrowser.java
@@ -21,9 +21,9 @@ import java.net.URL;
  */
 public class ViewVCRepositoryBrowser extends SubversionRepositoryBrowser {
 
-	private static final String CHANGE_SET_FORMAT = "viewvc/?view=rev&root=%s&revision=%d";
-	private static final String DIFF_FORMAT = "viewvc/%s?root=%s&r1=%d&r2=%d&diff_format=h";
-	private static final String FILE_FORMAT = "viewvc/%s?root=%s&view=markup";
+	private static final String CHANGE_SET_FORMAT = "viewvc/%s/?view=rev&revision=%d";
+	private static final String DIFF_FORMAT = "viewvc/%s/%s?r1=%d&r2=%d&diff_format=h";
+	private static final String FILE_FORMAT = "viewvc/%s/%s?view=markup";
 
 	public final URL url;
 	private final String location;
@@ -35,18 +35,23 @@ public class ViewVCRepositoryBrowser extends SubversionRepositoryBrowser {
 	}
 
     public String getLocation() {
-        if(location==null)  return "/";
-        return location;
+        if(location == null || location.length() == 0) {
+          return "/";
+        } else if (location.endsWith("/")) {
+          return location.substring(0, location.length() - 1);
+        } else {
+          return location;
+        }
     }
 
     @Override
     public URL getDiffLink(Path path) throws IOException {
-		return new URL(url, String.format(DIFF_FORMAT, path.getValue(), getLocation(), path.getLogEntry().getRevision() - 1, path.getLogEntry().getRevision()));
+		return new URL(url, String.format(DIFF_FORMAT, getLocation(), path.getValue(), path.getLogEntry().getRevision() - 1, path.getLogEntry().getRevision()));
     }
 
     @Override
     public URL getFileLink(Path path) throws IOException {
-    	return new URL(url, String.format(FILE_FORMAT, path.getValue(), getLocation()));
+    	return new URL(url, String.format(FILE_FORMAT, getLocation(), path.getValue()));
     }
 
     @Override


### PR DESCRIPTION
The root URL parameter which was previously used in this plugin isn't working with the ViewVC which is bundled with Subversion Edge. As far as I have understood the ViewVC documentation, 'default_root' could be used instead of the URL parameters. In Subversion Edge, this parameter is configured to 'svn' and 'root_as_url_component' is set to 1.

Could you please test if this change is working properly with the ViewVC version of your Subversion installation? Or do you have an alternative idea how we could implement the plugin without the need of a ViewVC configuration change?
