### PR TITLE
[FIXED JENKINS-18283] Wrong URL in diff (and file view)

### DIFF
--- a/src/main/java/hudson/plugins/viewVC/ViewVCRepositoryBrowser.java
+++ b/src/main/java/hudson/plugins/viewVC/ViewVCRepositoryBrowser.java
@@ -63,12 +63,22 @@ public class ViewVCRepositoryBrowser extends SubversionRepositoryBrowser {
 
     @Override
     public URL getDiffLink(Path path) throws IOException {
-		return new URL(getUrl(), String.format(DIFF_FORMAT, path.getValue(), getLocation(), path.getLogEntry().getRevision() - 1, path.getLogEntry().getRevision()));
+        String baseUrl = getUrl().toString();
+        // eliminate trailing slash since the SVN path already has it
+        if (baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+		return new URL(baseUrl + String.format(DIFF_FORMAT, path.getValue(), getLocation(), path.getLogEntry().getRevision() - 1, path.getLogEntry().getRevision()));
     }
 
     @Override
     public URL getFileLink(Path path) throws IOException {
-    	return new URL(getUrl(), String.format(FILE_FORMAT, path.getValue(), getLocation()));
+        String baseUrl = getUrl().toString();
+        // eliminate trailing slash since the SVN path already has it
+        if (baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+    	return new URL(baseUrl + String.format(FILE_FORMAT, path.getValue(), getLocation()));
     }
 
     @Override

--- a/src/main/webapp/help-url.html
+++ b/src/main/webapp/help-url.html
@@ -1,3 +1,3 @@
 <div>
-  Set the URL of ViewVC installation, such as <tt>http://www.mysvnserver.domain.com/</tt> 
+  Set the URL of ViewVC installation, such as <tt>http://www.mysvnserver.domain.com/svn-bin/viewvc.cgi</tt> 
 </div>


### PR DESCRIPTION
When ViewVC is not install at root of server (http://www.mysvnserver.domain.com/) , for example: 
http://www.mysvnserver.domain.com/viewvc
or
http://www.mysvnserver.domain.com/bin/viewvc.cgi

Then the diff link and view file link is not correct because it will append the SVN path to the bare URL (i.e. lost the "context" path):
http://www.mysvnserver.domain.com/SVN/path/here/as/checked/out/myfile.txt

The patch is my attempt to fix those URLs.
